### PR TITLE
[HumanBenchmark][Backend][Caching] implementing recommended friends cache

### DIFF
--- a/back-end/prisma/migrations/20250714214255_cache/migration.sql
+++ b/back-end/prisma/migrations/20250714214255_cache/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "FriendRecommendation" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "recommendedUserId" INTEGER NOT NULL,
+    "score" DOUBLE PRECISION NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "FriendRecommendation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FriendRecommendation_userId_recommendedUserId_key" ON "FriendRecommendation"("userId", "recommendedUserId");
+
+-- AddForeignKey
+ALTER TABLE "FriendRecommendation" ADD CONSTRAINT "FriendRecommendation_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FriendRecommendation" ADD CONSTRAINT "FriendRecommendation_recommendedUserId_fkey" FOREIGN KEY ("recommendedUserId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/back-end/prisma/schema.prisma
+++ b/back-end/prisma/schema.prisma
@@ -35,6 +35,9 @@ model User {
   latitude          Float           @default(0)
   longitude         Float           @default(0)
 
+  recommendations   FriendRecommendation[] @relation("RecommendationsFor")
+  recommendedToOthers   FriendRecommendation[] @relation("RecommendedUsers")
+
 
   //prisma requires these
   friendshipsInitiated Friendship[] @relation("UserAsInitiator")
@@ -50,6 +53,19 @@ model Friendship{
   friend      User @relation("UserAsReceiver", fields: [friendId], references: [id])
 
   @@id([userId, friendId]) //enforces uniqueness
+}
+
+model FriendRecommendation{
+  id                     Int @id @default(autoincrement())
+  userId                 Int
+  recommendedUserId      Int
+  score                  Float
+  createdAt              DateTime @default(now())
+
+  user                   User @relation("RecommendationsFor", fields: [userId], references: [id])
+  recommendedUser        User @relation("RecommendedUsers", fields: [recommendedUserId], references: [id])
+
+  @@unique([userId, recommendedUserId])
 }
 
 model Exercise { // directly replects the API


### PR DESCRIPTION
I added a new data model called FriendRecommendation to create user cache.

The function to fetch user recommendations now checks the cache first before creating a new one

The users cache is updated every time a friend request is made.

This increased network performance dramatically

Attached is the before and after network performance.
<img width="480" height="21" alt="Screenshot 2025-07-14 at 3 06 15 PM" src="https://github.com/user-attachments/assets/5f2e8500-ba2e-4ab2-9910-5e5c93122559" />
<img width="483" height="23" alt="Screenshot 2025-07-14 at 3 06 37 PM" src="https://github.com/user-attachments/assets/543c9908-a037-41d1-93b5-868aa806e0e4" />
