### PR TITLE
[HumanBenchmark][Frontend][Backend][SuggestedTimes] add new suggested time algorithm

### DIFF
--- a/back-end/api/events-model.js
+++ b/back-end/api/events-model.js
@@ -1,0 +1,177 @@
+const { PrismaClient } = require("@prisma/client");
+
+const MILLISECONDS_PER_MINUTE = 1000 * 60;
+
+function scoreByEventFrequency(events, day, hour) {
+  return events.filter((event) => {
+    const date = new Date(event.start);
+    return date.getDay() === day && date.getHours() === hour;
+  }).length;
+}
+
+function scoreByLeavePatterns(leaves, hour) {
+  return -leaves.filter((leave) => new Date(leave).getHours() === hour).length;
+}
+
+function scoreByWorkoutHabit(completedWorkouts, day, selected) {
+  if (!selected || !selected.movements || !Array.isArray(selected.movements)) {
+    console.warn("selectedWorkout is null or has no valid movements.");
+    return 0;
+  }
+
+  try {
+    const targetParts = new Set(
+      selected.movements
+        .filter((m) => m && m.bodyPart)
+        .map((m) => m.bodyPart.toLowerCase())
+    );
+
+    let score = 0;
+    completedWorkouts.forEach((workout) => {
+      const logDay = new Date(workout.createdAt).getDay();
+      if (logDay !== day) return;
+
+      if (Array.isArray(workout.movements)) {
+        workout.movements.forEach((movement) => {
+          if (
+            movement &&
+            movement.bodyPart &&
+            targetParts.has(movement.bodyPart.toLowerCase())
+          ) {
+            score++;
+          }
+        });
+      }
+    });
+
+    return score;
+  } catch (err) {
+    console.error("Error in scoreByWorkoutHabit:", err);
+    return 0;
+  }
+}
+
+module.exports = {
+  async findFreeTimes(events, chunkLength) {
+    const freeSlots = [];
+    const seen = new Set();
+    const now = new Date();
+
+    // Group events by day
+    const eventsByDay = {};
+    for (let event of events) {
+      const dateKey = event.start.toISOString().split("T")[0];
+      if (!eventsByDay[dateKey]) eventsByDay[dateKey] = [];
+      eventsByDay[dateKey].push({
+        start: new Date(event.start),
+        end: new Date(event.end),
+      });
+    }
+
+    // today through the next 6 days (7 days total)
+    for (let i = 0; i < 7; i++) {
+      const date = new Date(now);
+      date.setDate(now.getDate() + i);
+      const dateKey = date.toISOString().split("T")[0];
+
+      const dailyEvents = (eventsByDay[dateKey] || []).sort(
+        (a, b) => a.start - b.start
+      );
+      let current;
+      if (dateKey === now.toISOString().split("T")[0]) {
+        current = new Date();
+        current.setSeconds(0, 0); // Remove seconds/millis
+        current.setMinutes(0); // Remove minutes
+      } else {
+        current = new Date(`${dateKey}T00:00:00`);
+      }
+      const endOfDay = new Date(`${dateKey}T23:59:00`);
+
+      for (let event of dailyEvents) {
+        while (
+          current.getTime() + chunkLength * MILLISECONDS_PER_MINUTE <
+          event.start.getTime()
+        ) {
+          let potentialStart = new Date(current);
+
+          // round potentialStart to nearest 15-min mark if not already
+          const startMinutes = potentialStart.getMinutes();
+          const startOffset =
+            startMinutes % 15 === 0 ? 0 : 15 - (startMinutes % 15);
+          if (startOffset > 0) {
+            potentialStart.setMinutes(startMinutes + startOffset);
+            potentialStart.setSeconds(0, 0);
+          }
+
+          // set potentialEnd to original potentialStart + chunkLength
+          let potentialEnd = new Date(
+            potentialStart.getTime() + chunkLength * MILLISECONDS_PER_MINUTE
+          );
+
+          // round potentialEnd to the next 15-minute mark
+          const endMinutes = potentialEnd.getMinutes();
+          const remainder = endMinutes % 15;
+          if (remainder !== 0) {
+            potentialEnd.setMinutes(endMinutes + (15 - remainder));
+            potentialEnd.setSeconds(0, 0);
+          }
+
+          // make sure potentialEnd is still after potentialStart
+          if (potentialEnd <= potentialStart) {
+            console.warn("Skipping invalid time range", {
+              potentialStart,
+              potentialEnd,
+            });
+            break; // or skip
+          }
+
+          const key = potentialStart.toISOString();
+          if (!seen.has(key) && potentialStart >= now) {
+            freeSlots.push({ start: potentialStart, end: potentialEnd });
+            seen.add(key);
+          }
+          current = potentialEnd;
+        }
+
+        if (event.end > current) {
+          current = event.end;
+        }
+      }
+
+      while (
+        current.getTime() + chunkLength * MILLISECONDS_PER_MINUTE <=
+        endOfDay.getTime()
+      ) {
+        const potentialStart = new Date(current);
+        const potentialEnd = new Date(
+          current.getTime() + chunkLength * MILLISECONDS_PER_MINUTE
+        );
+        const key = potentialStart.toISOString();
+        if (!seen.has(key) && potentialStart >= now) {
+          freeSlots.push({ start: potentialStart, end: potentialEnd });
+          seen.add(key);
+        }
+        current = potentialEnd;
+      }
+    }
+
+    return freeSlots;
+  },
+
+  async rankSuggestedTimes(times, events, leaves, logs, selectedWorkout) {
+    return times
+      .map((slot) => {
+        const start = new Date(slot.start);
+        const day = start.getDay();
+        const hour = start.getHours();
+
+        const score =
+          scoreByEventFrequency(events, day, hour) +
+          scoreByLeavePatterns(leaves, hour) +
+          scoreByWorkoutHabit(logs, day, selectedWorkout);
+
+        return { ...slot, score };
+      })
+      .sort((a, b) => b.score - a.score);
+  },
+};

--- a/back-end/api/model-prisma.js
+++ b/back-end/api/model-prisma.js
@@ -10,7 +10,7 @@ const MUTUAL_FRIENDS_WEIGHT = 0.4;
 const WORKOUT_FREQUENCY_WEIGHT = 0.225;
 const AGE_DIFFERENCE_WEIGHT = 0.15;
 const GEO_DISTANCE_WEIGHT = 0.225;
-const MILLISECONDS_PER_MINUTE = 1000 * 60;
+
 
 function calculateXP(movement) {
   // Should take user roughly 3 workouts to level up
@@ -619,98 +619,4 @@ module.exports = {
     });
   },
 
-  async findFreeTimes(events, chunkLength) {
-    const freeSlots = [];
-    const seen = new Set();
-    const now = new Date();
-
-    // Group events by day
-    const eventsByDay = {};
-    for (let event of events) {
-      const dateKey = event.start.toISOString().split("T")[0];
-      if (!eventsByDay[dateKey]) eventsByDay[dateKey] = [];
-      eventsByDay[dateKey].push({
-        start: new Date(event.start),
-        end: new Date(event.end),
-      });
-    }
-
-    // today through the next 6 days (7 days total)
-    for (let i = 0; i < 7; i++) {
-      const date = new Date(now);
-      date.setDate(now.getDate() + i);
-      const dateKey = date.toISOString().split("T")[0];
-
-      const dailyEvents = (eventsByDay[dateKey] || []).sort(
-        (a, b) => a.start - b.start
-      );
-      let current;
-      if (dateKey === now.toISOString().split("T")[0]) {
-        current = new Date();
-        current.setSeconds(0, 0); // Remove seconds/millis
-        current.setMinutes(0); // Remove minutes
-      } else {
-        current = new Date(`${dateKey}T00:00:00`);
-      }
-      const endOfDay = new Date(`${dateKey}T23:59:00`);
-
-      for (let event of dailyEvents) {
-        while (
-          current.getTime() + chunkLength * MILLISECONDS_PER_MINUTE <
-          event.start.getTime()
-        ) {
-          let potentialStart = new Date(current);
-
-          // round potentialStart to nearest 15-min mark if not already
-          const startMinutes = potentialStart.getMinutes();
-          const startOffset =
-            startMinutes % 15 === 0 ? 0 : 15 - (startMinutes % 15);
-          if (startOffset > 0) {
-            potentialStart.setMinutes(startMinutes + startOffset);
-            potentialStart.setSeconds(0, 0);
-          }
-
-          // set potentialEnd to original potentialStart + chunkLength
-          let potentialEnd = new Date(
-            potentialStart.getTime() + chunkLength * MILLISECONDS_PER_MINUTE
-          );
-
-          // if end time has minutes, truncate to the last full hour
-          if (potentialEnd.getMinutes() !== 0) {
-            potentialEnd.setMinutes(0);
-            potentialEnd.setSeconds(0, 0);
-          }
-
-          const key = potentialStart.toISOString();
-          if (!seen.has(key) && potentialStart >= now) {
-            freeSlots.push({ start: potentialStart, end: potentialEnd });
-            seen.add(key);
-          }
-          current = potentialEnd;
-        }
-
-        if (event.end > current) {
-          current = event.end;
-        }
-      }
-
-      while (
-        current.getTime() + chunkLength * MILLISECONDS_PER_MINUTE <=
-        endOfDay.getTime()
-      ) {
-        const potentialStart = new Date(current);
-        const potentialEnd = new Date(
-          current.getTime() + chunkLength * MILLISECONDS_PER_MINUTE
-        );
-        const key = potentialStart.toISOString();
-        if (!seen.has(key) && potentialStart >= now) {
-          freeSlots.push({ start: potentialStart, end: potentialEnd });
-          seen.add(key);
-        }
-        current = potentialEnd;
-      }
-    }
-
-    return freeSlots;
-  },
 };

--- a/back-end/prisma/migrations/20250718182608_event_leave/migration.sql
+++ b/back-end/prisma/migrations/20250718182608_event_leave/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "EventLeave" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "eventId" INTEGER NOT NULL,
+    "leftAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "EventLeave_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "EventLeave_userId_eventId_key" ON "EventLeave"("userId", "eventId");
+
+-- AddForeignKey
+ALTER TABLE "EventLeave" ADD CONSTRAINT "EventLeave_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EventLeave" ADD CONSTRAINT "EventLeave_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "CalendarEvent"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/back-end/prisma/schema.prisma
+++ b/back-end/prisma/schema.prisma
@@ -40,6 +40,7 @@ model User {
 
   createdEvents         CalendarEvent[]          @relation("UserCreatedEvents")
   joinedEvents          CalendarEvent[]          @relation("EventParticipants")
+  eventLeaves           EventLeave[]             @relation("UserEventLeaves")
 
 
   //prisma requires these
@@ -60,8 +61,21 @@ model CalendarEvent {
 
   workoutId    Int?       @unique
   workout      Workout?   @relation("WorkoutEvent", fields: [workoutId], references: [id])
+
+  eventLeaves  EventLeave[] @relation("EventLeaves")
+
 }
 
+model EventLeave {
+  id         Int           @id @default(autoincrement())
+  user       User          @relation("UserEventLeaves", fields: [userId], references: [id])
+  userId     Int
+  event      CalendarEvent @relation("EventLeaves", fields: [eventId], references: [id])
+  eventId    Int
+  leftAt     DateTime      @default(now())
+
+  @@unique([userId, eventId])
+}
 
 
 model Friendship{


### PR DESCRIPTION
Created a new `events-model.js` for refactoring purposes
Added a new EventLeave data model to track when a user leaves an event.

Suggested times are now ranked by:
- User event time frequency
- User leaving event patter (subtract form score)
- User workout habits (movements)


I had to redo the truncating logic in `findFreeTimes` to prevent server crash
I updated some naming conventions

Next step is to implement the EventLeave logic when user leaves event.


Attached is an image of the endpoint return with scores
<img width="1014" height="619" alt="Screenshot 2025-07-18 at 3 01 39 PM" src="https://github.com/user-attachments/assets/76b71d32-889b-453b-8763-deb25e8df371" />