### PR TITLE
[HumanBenchmark][Backend][FriendRecommendation] add BFS search to mutual friend factor

### DIFF
--- a/back-end/api/socialGraph/socialGraph-model.js
+++ b/back-end/api/socialGraph/socialGraph-model.js
@@ -179,8 +179,7 @@ module.exports = {
           const score = await getRecommendationScore(
             user,
             potential,
-            dynamicWeights,
-            mutualCount
+            dynamicWeights
           );
           return { friend: potential, score };
         })

--- a/back-end/api/socialGraph/socialGraphHelper.js
+++ b/back-end/api/socialGraph/socialGraphHelper.js
@@ -151,11 +151,6 @@ async function getRecommendationScore(user, friend, weights) {
   const geoScore = getGeoDistanceScore(user, friend);
   const mutualScore = await getMutualFriendScore(user.id, friend.id);
 
-  console.log("mutualScore: ", mutualScore);
-  console.log("ageScore: ", ageScore);
-  console.log("workoutScore: ", workoutScore);
-  console.log("geoScore: ", geoScore);
-
   let score = 0;
   score += weights.mutual * mutualScore;
   score += weights.age * ageScore;


### PR DESCRIPTION
I added a helper function `getMutualFriendScore` to perform a breadth first search through the social graph, up to 5 degrees

Instead of just counting direct mutual friends, the function will give a higher weight to the closer connections.