### PR TITLE
[HumanBenchmark][Backend][FriendRecommendation] optimize friend recommendation algorithm

### DIFF
--- a/back-end/api/socialGraph/socialGraph-model.js
+++ b/back-end/api/socialGraph/socialGraph-model.js
@@ -151,45 +151,71 @@ module.exports = {
       }
 
       // Otherwise, generate new cache
-      const friendships = await prisma.friendship.findMany({
-        where: {
-          OR: [{ userId }, { friendId: userId }],
-          status: ACCEPTED_STATUS,
+      const allFriendships = await prisma.friendship.findMany({
+        where: { status: ACCEPTED_STATUS },
+      });
+
+      const friendMap = new Map(); // build map to reuse
+      for (const { userId, friendId } of allFriendships) {
+        if (!friendMap.has(userId)) friendMap.set(userId, new Set());
+        if (!friendMap.has(friendId)) friendMap.set(friendId, new Set());
+        friendMap.get(userId).add(friendId);
+        friendMap.get(friendId).add(userId);
+      }
+
+      const friendIds = Array.from(friendMap.get(userId) || []);
+
+      const user = await prisma.user.findUnique({
+        where: { id: userId },
+        include: {
+          workouts: {
+            include: { movements: true },
+          },
         },
       });
 
-      const friendIds = getFriendIds(friendships, userId);
-
-      const user = await prisma.user.findUnique({ where: { id: userId } });
       const userFriends = await prisma.user.findMany({
         where: { id: { in: friendIds } },
+        include: {
+          workouts: {
+            include: { movements: true },
+          },
+        },
       });
       const dynamicWeights = await getDynamicWeights(user, userFriends);
 
       // Fetch all users except the current user
       const allUsers = await prisma.user.findMany({
-        where: { id: { not: userId, notIn: friendIds } },
+        where: {
+          id: {
+            not: userId,
+            notIn: friendIds,
+          },
+        },
+        include: {
+          workouts: {
+            include: { movements: true },
+          },
+        },
       });
 
       // Calculate recommendation scores for each user
       const recommendations = await Promise.all(
         allUsers.map(async (potential) => {
-          const mutualCount = (await getMutualFriends(userId, potential.id))
-            .length;
           const score = await getRecommendationScore(
             user,
             potential,
-            dynamicWeights
+            dynamicWeights,
+            friendMap // pass in friendMap to reuse
           );
           return { friend: potential, score };
         })
       );
 
-      // Sort by score in descending order
-      recommendations.sort((a, b) => b.score - a.score);
-
-      // Get top 50 recommendations
-      const top = recommendations.slice(0, 50);
+      // Get top 50 recommendations sorted
+      const top = recommendations
+        .sort((a, b) => b.score - a.score)
+        .slice(0, 50);
 
       // Clear old cache
       await prisma.friendRecommendation.deleteMany({ where: { userId } });


### PR DESCRIPTION
To optimize the code, I took these steps:
- Batch-load workouts from users
- Built a `friendMap` to be reused
- reused the `friendMap` in `getMutualFriendScore`
- remove duplicate `getMutualFriends` call

These changes were able to increase the get recommended friends endpoint speed from **148ms** to **86ms**

The first image is before optimization
<img width="514" height="35" alt="Screenshot 2025-07-22 at 1 33 29 PM" src="https://github.com/user-attachments/assets/240aca78-b506-4be2-a083-6742921ae74a" />

The second image is after
<img width="515" height="33" alt="Screenshot 2025-07-22 at 1 56 46 PM" src="https://github.com/user-attachments/assets/bfbde3dc-0650-46c2-845c-0e5e08ebb992" />

**Note:** I accidentally pushed these changes to main the first time. I tried to fix it, but I think in doing so this PR contains the last one

