### PR TITLE
[HumanBenchmark][Frontend][Leaderboard] add show friends only feature

### DIFF
--- a/front-end/src/LeaderboardPage/LeaderboardPage.jsx
+++ b/front-end/src/LeaderboardPage/LeaderboardPage.jsx
@@ -17,6 +17,7 @@ const LeaderboardPage = () => {
   const [sortKey, setSortKey] = useState(OVERALL_STAT_KEY);
   const [searchQuery, setSearchQuery] = useState("");
   const [filteredUsers, setFilteredUsers] = useState([]);
+  const [showOnlyFriends, setShowOnlyFriends] = useState(false);
 
   useEffect(() => {
     if (user && user.id) {
@@ -107,6 +108,14 @@ const LeaderboardPage = () => {
     setFilteredUsers(users);
   };
 
+  const toggleShowOnlyFriends = () => {
+    setShowOnlyFriends((prev) => !prev);
+  };
+
+  const displayedUsers = showOnlyFriends
+    ? filteredUsers.filter((user) => friends.includes(user.id))
+    : filteredUsers;
+
   return (
     <div>
       <div className="container">
@@ -129,6 +138,12 @@ const LeaderboardPage = () => {
             </button>
             <button className="leaderboard-search-button" onClick={clearSearch}>
               Clear
+            </button>
+            <button
+              className="leaderboard-search-button"
+              onClick={toggleShowOnlyFriends}
+            >
+              {showOnlyFriends ? "Show Everyone" : "Show Only Friends"}
             </button>
           </div>
 
@@ -165,7 +180,7 @@ const LeaderboardPage = () => {
               </tr>
             </thead>
             <tbody>
-              {filteredUsers.map((leaderboardUser) => {
+              {displayedUsers.map((leaderboardUser) => {
                 const isFriend = friends.includes(leaderboardUser.id);
                 const isPending = pendingRequests.includes(leaderboardUser.id);
                 const isCurrentUser = user.id === leaderboardUser.id;

--- a/front-end/src/LeaderboardPage/LeaderboardPage.jsx
+++ b/front-end/src/LeaderboardPage/LeaderboardPage.jsx
@@ -113,7 +113,10 @@ const LeaderboardPage = () => {
   };
 
   const displayedUsers = showOnlyFriends
-    ? filteredUsers.filter((user) => friends.includes(user.id))
+    ? filteredUsers.filter(
+        (leaderboardUser) =>
+          friends.includes(leaderboardUser.id) || leaderboardUser.id === user.id
+      )
     : filteredUsers;
 
   return (


### PR DESCRIPTION
I added a button to toggle the shown users on leaderboard. You can toggle between everyone and just friends


https://github.com/user-attachments/assets/f03ffbf0-c6aa-42a5-91c9-aa05a625d3a7

